### PR TITLE
Enable the propagation of the existing route table on AWS

### DIFF
--- a/.tofu/template-tfs/ha-vpn-tunnels/aws-networking.tf
+++ b/.tofu/template-tfs/ha-vpn-tunnels/aws-networking.tf
@@ -83,19 +83,19 @@ resource "aws_vpn_connection" "my-aws-cx-2" {
 #        to import them into the state file.
 
 # Create a Route Table and add a route to the VPN Connection
-resource "aws_route_table" "my-aws-rt" {
-  tags = {
-    Name = "my-aws-rt-name"
-  }
+# resource "aws_route_table" "my-aws-rt" {
+#   tags = {
+#     Name = "my-aws-rt-name"
+#   }
   
-  vpc_id = var.my-imported-aws-vpc-id
-  propagating_vgws = [aws_vpn_gateway.my-aws-vpn-gateway.id]
-}
+#   vpc_id = var.my-imported-aws-vpc-id
+#   propagating_vgws = [aws_vpn_gateway.my-aws-vpn-gateway.id]
+# }
 
-# Create a Route Table Association between the Route Table and the Subnet
-resource "aws_route_table_association" "my-aws-rta-1" {
-  # count = 3
-  # subnet_id = element(aws_subnet.main.*.id, count.index)
-  subnet_id = var.my-imported-aws-subnet-id
-  route_table_id = aws_route_table.my-aws-rt.id
-}
+# # Create a Route Table Association between the Route Table and the Subnet
+# resource "aws_route_table_association" "my-aws-rta-1" {
+#   # count = 3
+#   # subnet_id = element(aws_subnet.main.*.id, count.index)
+#   subnet_id = var.my-imported-aws-subnet-id
+#   route_table_id = aws_route_table.my-aws-rt.id
+# }

--- a/.tofu/template-tfs/ha-vpn-tunnels/imports.tf
+++ b/.tofu/template-tfs/ha-vpn-tunnels/imports.tf
@@ -1,0 +1,19 @@
+# Import a route table from the AWS provider
+import {
+  to = aws_route_table.my-imported-aws-route-table
+  id = data.aws_route_table.imported.id
+}
+
+# This is an imported AWS Route Table.
+# Thus, it must NOT be destroyed by Tofu.
+# Run `tofu state rm aws_route_table.my-imported-aws-route-table` to remove it from the state file.
+resource "aws_route_table" "my-imported-aws-route-table" {
+  tags = data.aws_route_table.imported.tags
+  
+  vpc_id = var.my-imported-aws-vpc-id
+  propagating_vgws = [aws_vpn_gateway.my-aws-vpn-gateway.id]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/.tofu/template-tfs/ha-vpn-tunnels/variables.tf
+++ b/.tofu/template-tfs/ha-vpn-tunnels/variables.tf
@@ -10,6 +10,19 @@ variable "my-imported-aws-subnet-id" {
   description = "The ID of the AWS subnet to use for the HA VPN tunnels."
 }
 
+# variable "my-imported-aws-route-table-id" {
+#   type        = string
+#   description = "The ID of the AWS route table to use for the HA VPN tunnels."
+# }
+
+data "aws_route_table" "imported" {
+  subnet_id = var.my-imported-aws-subnet-id
+}
+
+# output "my-imported-aws-route-table-tags" {
+#   value = data.aws_route_table.imported.tags
+# }
+
 ## GCP variables
 # VPC
 variable "my-imported-gcp-vpc-name" {

--- a/pkg/tofu/tofu.go
+++ b/pkg/tofu/tofu.go
@@ -133,3 +133,13 @@ func SaveTfVarsToFile(tfVars models.TfVarsVPNTunnels, filePath string) error {
 
 	return nil
 }
+
+func TruncateFile(filename string) error {
+    file, err := os.OpenFile(filename, os.O_TRUNC, 0644)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    return nil
+}


### PR DESCRIPTION
The PR will enable the propagation on the existing route table on AWS.

Finally, it is possible to 🚀 
- register and use external resources, and 
- prevent them from being deleted when destroyed.

For further details, please refer to the following.
* Fetch/get the information of the route table by the ID of the associated subnet ID
```hcl
data "aws_route_table" "imported" {
  subnet_id = var.my-imported-aws-subnet-id
}
```

* Import the existing route table as a `resource` in Tofu
* Set `prevent_destroy` true to the imported route table
```hcl
# Import a route table from the AWS provider
import {
  to = aws_route_table.my-imported-aws-route-table
  id = data.aws_route_table.imported.id
}

# This is an imported AWS Route Table.
# Thus, it must NOT be destroyed by Tofu.
# Run `tofu state rm aws_route_table.my-imported-aws-route-table` to remove it from the state file.
resource "aws_route_table" "my-imported-aws-route-table" {
  tags = data.aws_route_table.imported.tags

  vpc_id = var.my-imported-aws-vpc-id
  propagating_vgws = [aws_vpn_gateway.my-aws-vpn-gateway.id]

  lifecycle {
    prevent_destroy = true
  }
}
```

* To avoid removing the imported resource when `tofu destroys`
  * Remove the state of the resource by `tofu state rm ***`
```go
ret, err := tofu.ExecuteCommand("-chdir="+workingDir, "state", "rm", "aws_route_table.my-imported-aws-route-table")
```
  * Truncate `imports.tf` to remove the `import` and `resource` section
```go
err = tofu.TruncateFile(workingDir + "/imports.tf")
```

Close #17 

(CC. @seokho-son)